### PR TITLE
feat: add organisation-wide pr template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # .github
-Organization repo for templates and general stuff
+
+Default [community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for The Avonova Solutions's development department.
+
+

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -19,5 +19,8 @@ Please describe how you verify your changes. Provide instructions so QA can repr
 
 # Checklist:
 
-- [ ] My code follows the style guidelines of this project
+- [ ] My code follows the style guidelines of our organization
 - [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have utilised feature flagging where appropriate
+- [ ] I have created / updated unit tests to verify my changes
+- [ ] I have created or updated relevant documentation


### PR DESCRIPTION
# Description

Add organisation wide PR template that will serve as a default for all repositories when creating new PRs.

# How Has This Been Tested?

Not been able to test this, just tried to follow the documentation: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file
