### PR TITLE
feat(pr-template): Remove 'Type of change' section

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,15 +4,6 @@ Please include a summary of the changes and the related issue. Please also inclu
 
 Fixes # (GitHub/Jira issue)
 
-## Type of change
-
-Please delete options that are not relevant.
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
 # How Has This Been Tested?
 
 Please describe how you verify your changes. Provide instructions so QA can reproduce.


### PR DESCRIPTION
# Description

The 'Type of change' section in the PR template duplicated the point with conventional commit PR title format. No need to repeat the info already given by CC. Hence, it can be removed to avoid unnecessary work describing PRs.